### PR TITLE
Fixes for Bolt 3.3+

### DIFF
--- a/src/BoltUIOptionsExtension.php
+++ b/src/BoltUIOptionsExtension.php
@@ -9,6 +9,7 @@ use Bolt\Extension\SimpleExtension;
 use Bolt\Extension\Snijder\BoltUIOptions\Controller\UIOptionsController;
 use Bolt\Extension\Snijder\BoltUIOptions\Provider\UIOptionsProvider;
 use Bolt\Menu\MenuEntry;
+use Bolt\Version;
 
 /**
  * Class BoltUIOptionsExtension.
@@ -74,16 +75,13 @@ class BoltUIOptionsExtension extends SimpleExtension
      */
     protected function registerBackendControllers()
     {
+        $extendBaseUrl = Version::compare('3.2.999', '<')
+            ? '/extensions/'
+            : '/extend/'
+        ;
+
         return [
-          '/extend/'.$this->backendURL => new UIOptionsController(
-              $this->container['twig'],
-              $this->container['ui.options.config'],
-              $this->container['filesystem'],
-              $this->container['url_generator'],
-              $this->container['session'],
-              sprintf('config://extensions/%s.%s.yml', strtolower($this->getName()), strtolower($this->getVendor())),
-              'theme://theme.yml'
-          ),
+            $extendBaseUrl . $this->backendURL => new UIOptionsController(),
         ];
     }
 

--- a/src/Provider/UIOptionsProvider.php
+++ b/src/Provider/UIOptionsProvider.php
@@ -77,6 +77,16 @@ class UIOptionsProvider implements ServiceProviderInterface
 
             return $config;
         });
+
+        $app['ui.options.config.file'] = $app->share(
+            function ($app) {
+                $extension = $app['extensions']->get('Snijder/BoltUIOptions');
+                $filePath = sprintf('config://extensions/%s.%s.yml', strtolower($extension->getName()), strtolower($extension->getVendor()));
+
+                return $app['filesystem']->get($filePath);
+            }
+        );
+
     }
 
     /**


### PR DESCRIPTION
Upcoming changes show some problems that are hopefully all caught in this PR.

Right now in `release/3.3` the early invocation of services to build the controller object causes a fatal loop.

This PR:
  * Prevent invoking request cycle services during registration
  * Handle Bolt 3.3 backend route name change, with BC for prior versions of Bolt

Ideally the `boot()` should go too, and you just pass what you need to the helper functions. But your call down the track :smile: 