### PR TITLE
Redirect unauthorised users

### DIFF
--- a/src/Controller/UIOptionsController.php
+++ b/src/Controller/UIOptionsController.php
@@ -64,6 +64,11 @@ class UIOptionsController implements ControllerProviderInterface
      */
     public function before(Request $request, Application $app)
     {
+        if (!$app['users']->isAllowed('dashboard')) {
+            /** @var UrlGeneratorInterface $generator */
+            $generator = $app['url_generator'];
+            return new RedirectResponse($generator->generate('dashboard'), Response::HTTP_SEE_OTHER);
+        }
         $this->config = $app['ui.options.config'];
         $this->filesystem = $app['filesystem'];
         $this->optionFile = $app['ui.options.config.file'];


### PR DESCRIPTION
Added a check to before() to ensure a user can access bolt dashboard before letting them in to the backend.

Currently you can go to /bolt/extensions/bolt-ui-options as an unauthenticated user and view/edit/update settings.