### PR TITLE
Trully allow theme OR extension file

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -41,7 +41,7 @@ class Config
      */
     public function __construct(array $config)
     {
-        $this->addExtensionTabs($config['ui-options']);
+        $this->addExtensionTabs(isset($config['ui-options']) ? $config['ui-options'] : []);
     }
 
     /**
@@ -162,6 +162,6 @@ class Config
 
     public function get()
     {
-        
+
     }
 }


### PR DESCRIPTION
This fixes a behaviour that's a bit annoying. 

I try to set some options in the `theme.yml` file. But I don't want to set any options in `app/config/extensions/boltuioptions.snijder.yml`. 

- If I delete the file, it's automatically created by the extension `getConfig` process (actually copied from `config/config.dist.yml`).
- If I leave the file empty, I get a warning `Warning: Invalid argument supplied for foreach()` in `Config/Config.php` line 54 because it passes a non array value.

This PR is a quick and dirty workaround addressing this bug. 

I'm also trying to add some fields programmatically to provide a field that can be able to select dynamic content (a page, or any contenttype). Any plans to add such field type? 

It's currently not very easy to achieve this (lacking public methods like `addThemeTabs`, `addExtensionsTabs` being protected). 

But that's another topic. I'll come back to it later 😉 