### PR TITLE
Check if array key exists as well as checking if null for getOptionValue

### DIFF
--- a/src/Controller/UIOptionsTwigFunctionController.php
+++ b/src/Controller/UIOptionsTwigFunctionController.php
@@ -35,7 +35,7 @@ class UIOptionsTwigFunctionController
     {
         $fields = $this->config->getFields();
 
-        if ($fields[$name] == null) {
+        if (!array_key_exists($name, $fields) || $fields[$name] == null) {
             return '';
         }
 

--- a/src/UIOptions.php
+++ b/src/UIOptions.php
@@ -35,7 +35,7 @@ class UIOptions
     {
         $fields = $this->config->getFields();
 
-        if ($fields[$slug] == null) {
+        if (!array_key_exists($slug, $fields) || $fields[$slug] == null) {
             return '';
         }
 


### PR DESCRIPTION
Prevent uncaught exception when trying to get value of key that doesn't exist in the boltuioptions, instead return empty value. 